### PR TITLE
Fix WiFi AP IP 0.0.0.0 / SD_MMC build error

### DIFF
--- a/include/tools/config_default.hpp
+++ b/include/tools/config_default.hpp
@@ -2,7 +2,7 @@
 /*
     Avoid changing this vile, change the config.hpp instead if you need custom configuration
 */
-#define PANDA_VERSION "3.0.1"
+#define PANDA_VERSION "3.0.2"
 /*
 Cache file version to invalidate cache in case of firmware update
 */

--- a/src/editmode/editmode.cpp
+++ b/src/editmode/editmode.cpp
@@ -205,8 +205,9 @@ void EditMode::DoBegin(bool connectToWifi)
   const char *ftpUser = ftp_conf["user"];
   const char *ftpPassword = ftp_conf["password"];
 
-  if (connectToWifi){
+  String deviceIP;
 
+  if (connectToWifi){
 
     const char *name = wifi_ssid["name"];
     const char *password = wifi_ssid["password"];
@@ -218,22 +219,25 @@ void EditMode::DoBegin(bool connectToWifi)
       Logger::Info("Trying...");
     }
     Logger::Info("Connected!");
+    deviceIP = WiFi.localIP().toString();
   }else{
-  
+
     const char *name = access_point["name"];
     const char *password = access_point["password"];
 
     WiFi.softAP(name, password);
+    delay(500);
+    deviceIP = WiFi.softAPIP().toString();
     Logger::Info("Network: %s", name);
     Logger::Info("Pass: %s", password);
   }
 
   if (editModePort == 80){
-    Logger::Info("http://%s", WiFi.localIP().toString().c_str());
+    Logger::Info("http://%s", deviceIP.c_str());
   }else{
-    Logger::Info("http://%s:%d", WiFi.localIP().toString().c_str(), editModePort);
+    Logger::Info("http://%s:%d", deviceIP.c_str(), editModePort);
   }
-  Logger::Info("FTP: %s:%d", WiFi.localIP().toString().c_str(), ftpPort);
+  Logger::Info("FTP: %s:%d", deviceIP.c_str(), ftpPort);
 
   ftpSrv = new FtpServer(ftpPort);
   luaServer = new WiFiServer(luaConsolePort);

--- a/src/editmode/wifiserver.cpp
+++ b/src/editmode/wifiserver.cpp
@@ -913,7 +913,7 @@ void startWifiServer(int port){
   server = new AsyncWebServer(port);
 
   server->on("/", HTTP_GET, serveDirectoryListing);
-  server->serveStatic("/", SD_MMC, "/", "max-age=0").setCacheControl("max-age=0");
+  server->serveStatic("/", PANDA_SD, "/", "max-age=0").setCacheControl("max-age=0");
   server->on("/mkdir", HTTP_POST, handleMkdir);
   server->on("/upload", HTTP_POST, [](AsyncWebServerRequest *request){ request->send(200); }, handleUpload);
   server->on("/delete", HTTP_DELETE, handleRm);


### PR DESCRIPTION
[fix] WiFi AP IP showing 0.0.0.0 on OLED screen (editmode.cpp)
- Added deviceIP string to store correct IP per WiFi mode
- AP mode: switched to WiFi.softAPIP() + delay(500) before reading IP
- Client mode: keeps WiFi.localIP() as before
- All Logger::Info calls for HTTP/FTP now use deviceIP

[fix] Build error: SD_MMC hardcoded in wifiserver.cpp
- Line 915: replaced SD_MMC with PANDA_SD macro so it respects the PANDA_SD_MODE setting (SPI or MMC)